### PR TITLE
Converting the VS build instructions wiki page to a step-by step guide

### DIFF
--- a/Compiling-With-Visual-Studio.md
+++ b/Compiling-With-Visual-Studio.md
@@ -1,43 +1,59 @@
-### Requirements
-To make builduing Thyme possible, you need to install the following programs:
+# Requirements
+To make builduing Thyme possible, you need to download and install the following programs:
 
 - Windows 7 / 8 / 10
+- [Git client](https://git-scm.com/downloads)
 - [CMake](https://cmake.org/download/)
 - Visual Studio 2015 or 2017: Enterprise, Professional or [Community (Free)](https://www.visualstudio.com/vs/community/) version
 - [DirectX SDK (juni 2010)](https://www.microsoft.com/en-us/download/details.aspx?id=6812)
 
-#### Visual Studio additional notes
+## Visual Studio additional notes
 
-For windows builds, the most straight forward compiler suite is the one provided by Visual Studio. When installing make sure you include the C++ development tools when given the option of what components to install.
+For windows builds, the most straight forward compiler suite is the one provided by Visual Studio. When installing make sure you include the C++ development tools when given the option of what components to install. Also, make sure to update Visual Studio to the latest version to prevent potential problems.
 
-#### DirectX SDK "S1023" error
+# Building Thyme
 
-At the end of the installation of the DirectX SDK a "S1023" could pop up. This error can be ignored and everything will be fine. But if you want to fix it, [these instructions](https://support.microsoft.com/en-us/help/2728613/s1023-error-when-you-install-the-directx-sdk-june-2010) can be followed.
+## Downloading the source using Cmake
 
-### Downloading the Source
+*Note: this could also be done by using [GitHub Desktop](https://desktop.github.com/), but in this guide we will asume you used the Git client.*
 
-Assuming you installed the mainline Windows Git client, open Git GUI and click "Clone Existing Respository"
+1. Assuming you installed the mainline Windows Git client, open Git GUI. 
+2. Click on "Clone Existing Respository"
 
 [[https://user-images.githubusercontent.com/2813117/36545868-d1fbae82-17e1-11e8-9cf8-b83aa7e9be92.png|alt=Clone%20Existing]]
 
-For the source location you want the address you get by clicking the "Clone or download" button on the main page of the github respository. The HTTPS address will probably work best. The target directory can be where ever is convenient on your system.
+3. Enter the source location and the target directory. For the source location you want 'https://github.com/TheAssemblyArmada/Thyme.git'. 
+4. Enter in the target directory. This can be where ever is convenient on your system.
 
 [[https://user-images.githubusercontent.com/2813117/36546502-8043bd76-17e3-11e8-8ebd-748c2c5edb81.png|alt=Clone%20Settings]]
 
-Now just click the "Clone" button and wait for the download to complete.
+4. Now just click the "Clone" button and wait for the download to complete.
 
-### Configuring with CMake
+## Configuring with CMake
 
-Open CMake (cmake-gui) and either browse to the directory that you cloned the repository to or just type it for the "Where is the source code" box. For the "Where to build the binarys" box we recommend that you use a subdirectory under the folder that you cloned to called "build" as in the screen shot below.
+5. Open CMake (cmake-gui).
+6. Either browse to the directory that you cloned the repository to (target directory) or just type it for the "Where is the source code" box. 
+7. For the "Where to build the binarys" box we recommend that you use a subdirectory under the folder that you cloned to called "build" as in the screen shot below.
 
 [[https://user-images.githubusercontent.com/2813117/36568134-c4a695e6-1820-11e8-885c-2a1f51e06769.png|alt=CMake%20Paths]]
 
-Click the "Configure" button and select the appropriate Visual Studio generator, either 2015 or 2017. To build a working .dll file, do not try to use the Win64 generators.
+8. Click the "Configure" button.
+9. Select the appropriate Visual Studio generator, either 2015 or 2017. This depends on which version of Visual Studio you previously installed. *Do not try to use the Win64 generators as this will produce a malfunctioning build.*
+10. Click on "Finish." *CMake will now do some testing to check you have working compilers installed and try and detect any required development libraries, such as the previously installed DirectX SDK.* 
 
 [[https://user-images.githubusercontent.com/2813117/36568247-2d2e0284-1821-11e8-9343-c2c79f45db90.png|alt=CMake%20Generator]]
 
-CMake will do some testing to check you have working compilers installed and try and detect any required development libraries, such as the DirectX SDK. Once complete, the main window of CMake will fill with the various parameters that will be used as part of the build. Provided there were no errors, this configuration shouldn't need any tweaking, so go ahead and click "Generate". This should generate a solution that you can load into Visual Studio in the build directory we specified initially in the CMake window.
+11. *Once complete, the main window of CMake will fill with the various parameters that will be used as part of the build. Provided there were no errors, this configuration shouldn't need any tweaking* If you see any errors you're not able to solve, contact us through our [Discord channel](https://discord.gg/YhdMbvD).
+12. Now, go ahead and click "Generate". *This should generate a solution that you can load into Visual Studio in the build directory we specified initially in the CMake window.*
 
 ### Compiling the Code
 
-Open Visual Studio and use the normal file open menu to find the .sln solution file that CMake generated in the build directory and open it. Select the "Build" menu item and "Build Solution" and the project should compile. When its finished under your build directory should be a directory named after the type of build (Debug, Release, RelWithDebInfo) containing thyme.dll and launchthyme.exe.
+13. Open Visual Studio 2015 or 2017. 
+14. Use the normal file open menu to find the .sln solution file that CMake generated in the build directory and open it.
+15. Select the "Build" menu item and lick on "Build Solution". Now the project should compile. *This can take a few minutes. When its finished, under your build directory should be a directory named after the type of build (Debug, Release, RelWithDebInfo). This directory contains your compiled 'thyme.dll' and 'launchthyme.exe'.*
+
+### Troubleshooting
+
+#### "S1023" error at the end of the installation of the DirectX SDK.
+
+At the end of the installation of the DirectX SDK a "S1023" could pop up. This error can be ignored and everything will be fine. But if you want to fix it, [these instructions](https://support.microsoft.com/en-us/help/2728613/s1023-error-when-you-install-the-directx-sdk-june-2010) can be followed.

--- a/Compiling-With-Visual-Studio.md
+++ b/Compiling-With-Visual-Studio.md
@@ -1,11 +1,22 @@
-### Additional Prerequisites
+### Requirements
+To make builduing Thyme possible, you need to install the following programs:
 
-In addition to CMake and Git which are required for building on any platform, you also need a compiler suite that will convert the source code into a usable program. For windows builds, the most straight forward compiler suite is the one provided by Visual Studio, the free community edition of which can be downloaded [here](https://www.visualstudio.com/vs/community/). When installing make sure you include the C++ development tools when given the option of what components to install.
+- Windows 7 / 8 / 10
+- [CMake](https://cmake.org/download/)
+- Visual Studio 2015 or 2017: Enterprise, Professional or [Community (Free)](https://www.visualstudio.com/vs/community/) version
+- [DirectX SDK (juni 2010)](https://www.microsoft.com/en-us/download/details.aspx?id=6812)
+
+#### Visual Studio additional notes
+
+For windows builds, the most straight forward compiler suite is the one provided by Visual Studio. When installing make sure you include the C++ development tools when given the option of what components to install.
+
+#### DirectX SDK "S1023" error
+
+At the end of the installation of the DirectX SDK a "S1023" could pop up. This error can be ignored and everything will be fine. But if you want to fix it, [these instructions](https://support.microsoft.com/en-us/help/2728613/s1023-error-when-you-install-the-directx-sdk-june-2010) can be followed.
 
 ### Downloading the Source
 
 Assuming you installed the mainline Windows Git client, open Git GUI and click "Clone Existing Respository"
-
 
 [[https://user-images.githubusercontent.com/2813117/36545868-d1fbae82-17e1-11e8-9cf8-b83aa7e9be92.png|alt=Clone%20Existing]]
 
@@ -25,7 +36,7 @@ Click the "Configure" button and select the appropriate Visual Studio generator,
 
 [[https://user-images.githubusercontent.com/2813117/36568247-2d2e0284-1821-11e8-9343-c2c79f45db90.png|alt=CMake%20Generator]]
 
-CMake will do some testing to check you have working compilers installed and try and detect any required development libraries such as the Direct3D SDK. Once complete, the main window of CMake will fill with the various parameters that will be used as part of the build. Provided there were no errors, this configuration shouldn't need any tweaking, so go ahead and click "Generate". This should generate a solution that you can load into Visual Studio in the build directory we specified initially in the CMake window.
+CMake will do some testing to check you have working compilers installed and try and detect any required development libraries, such as the DirectX SDK. Once complete, the main window of CMake will fill with the various parameters that will be used as part of the build. Provided there were no errors, this configuration shouldn't need any tweaking, so go ahead and click "Generate". This should generate a solution that you can load into Visual Studio in the build directory we specified initially in the CMake window.
 
 ### Compiling the Code
 

--- a/Compiling-With-Visual-Studio.md
+++ b/Compiling-With-Visual-Studio.md
@@ -1,19 +1,19 @@
 # Requirements
-To make builduing Thyme possible, you need to download and install the following programs:
+In order to build Thyme, you need to download and install the following programs:
 
 - Windows 7 / 8 / 10
 - [Git client](https://git-scm.com/downloads)
 - [CMake](https://cmake.org/download/)
-- Visual Studio 2015 or 2017: Enterprise, Professional or [Community (Free)](https://www.visualstudio.com/vs/community/) version
-- [DirectX SDK (juni 2010)](https://www.microsoft.com/en-us/download/details.aspx?id=6812)
+- Visual Studio 2017 or above: Enterprise, Professional or [Community (Free)](https://www.visualstudio.com/vs/community/) version
+- [DirectX8 SDK (august 2007)](https://www.microsoft.com/en-gb/download/details.aspx?id=13287)
 
 ## Visual Studio additional notes
 
-For windows builds, the most straight forward compiler suite is the one provided by Visual Studio. When installing make sure you include the C++ development tools when given the option of what components to install. Also, make sure to update Visual Studio to the latest version to prevent potential problems.
+When installing make sure you include the C++ development tools when given the option of what components to install. Also, make sure to update Visual Studio to the latest version to prevent potential problems.
 
 # Building Thyme
 
-## Downloading the source using Cmake
+## Downloading the source using git
 
 *Note: this could also be done by using [GitHub Desktop](https://desktop.github.com/), but in this guide we will asume you used the Git client.*
 
@@ -48,7 +48,7 @@ For windows builds, the most straight forward compiler suite is the one provided
 
 ## Compiling the Code
 
-14. Open Visual Studio 2015 or 2017. 
+14. Open Visual Studio 2017. 
 15. Use the normal file open menu to find the .sln solution file that CMake generated in the build directory and open it.
 16. Select the "Build" menu item and lick on "Build Solution". Now the project should compile. *This can take a few minutes. When its finished, under your build directory should be a directory named after the type of build (Debug, Release, RelWithDebInfo). This directory contains your compiled 'thyme.dll' and 'launchthyme.exe'.*
 

--- a/Compiling-With-Visual-Studio.md
+++ b/Compiling-With-Visual-Studio.md
@@ -46,14 +46,14 @@ For windows builds, the most straight forward compiler suite is the one provided
 12. *Once complete, the main window of CMake will fill with the various parameters that will be used as part of the build. Provided there were no errors, this configuration shouldn't need any tweaking* If you see any errors you're not able to solve, contact us through our [Discord channel](https://discord.gg/YhdMbvD).
 13. Now, go ahead and click "Generate". *This should generate a solution that you can load into Visual Studio in the build directory we specified initially in the CMake window.*
 
-### Compiling the Code
+## Compiling the Code
 
 14. Open Visual Studio 2015 or 2017. 
 15. Use the normal file open menu to find the .sln solution file that CMake generated in the build directory and open it.
 16. Select the "Build" menu item and lick on "Build Solution". Now the project should compile. *This can take a few minutes. When its finished, under your build directory should be a directory named after the type of build (Debug, Release, RelWithDebInfo). This directory contains your compiled 'thyme.dll' and 'launchthyme.exe'.*
 
-### Troubleshooting
+## Troubleshooting
 
-#### "S1023" error at the end of the installation of the DirectX SDK.
+### "S1023" error at the end of the installation of the DirectX SDK.
 
 At the end of the installation of the DirectX SDK a "S1023" could pop up. This error can be ignored and everything will be fine. But if you want to fix it, [these instructions](https://support.microsoft.com/en-us/help/2728613/s1023-error-when-you-install-the-directx-sdk-june-2010) can be followed.

--- a/Compiling-With-Visual-Studio.md
+++ b/Compiling-With-Visual-Studio.md
@@ -27,30 +27,30 @@ For windows builds, the most straight forward compiler suite is the one provided
 
 [[https://user-images.githubusercontent.com/2813117/36546502-8043bd76-17e3-11e8-8ebd-748c2c5edb81.png|alt=Clone%20Settings]]
 
-4. Now just click the "Clone" button and wait for the download to complete.
+5. Now just click the "Clone" button and wait for the download to complete.
 
 ## Configuring with CMake
 
-5. Open CMake (cmake-gui).
-6. Either browse to the directory that you cloned the repository to (target directory) or just type it for the "Where is the source code" box. 
-7. For the "Where to build the binarys" box we recommend that you use a subdirectory under the folder that you cloned to called "build" as in the screen shot below.
+6. Open CMake (cmake-gui).
+7. Either browse to the directory that you cloned the repository to (target directory) or just type it for the "Where is the source code" box. 
+8. For the "Where to build the binarys" box we recommend that you use a subdirectory under the folder that you cloned to called "build" as in the screen shot below.
 
 [[https://user-images.githubusercontent.com/2813117/36568134-c4a695e6-1820-11e8-885c-2a1f51e06769.png|alt=CMake%20Paths]]
 
-8. Click the "Configure" button.
-9. Select the appropriate Visual Studio generator, either 2015 or 2017. This depends on which version of Visual Studio you previously installed. *Do not try to use the Win64 generators as this will produce a malfunctioning build.*
-10. Click on "Finish." *CMake will now do some testing to check you have working compilers installed and try and detect any required development libraries, such as the previously installed DirectX SDK.* 
+9. Click the "Configure" button.
+10. Select the appropriate Visual Studio generator, either 2015 or 2017. This depends on which version of Visual Studio you previously installed. *Do not try to use the Win64 generators as this will produce a malfunctioning build.*
+11. Click on "Finish." *CMake will now do some testing to check you have working compilers installed and try and detect any required development libraries, such as the previously installed DirectX SDK.* 
 
 [[https://user-images.githubusercontent.com/2813117/36568247-2d2e0284-1821-11e8-9343-c2c79f45db90.png|alt=CMake%20Generator]]
 
-11. *Once complete, the main window of CMake will fill with the various parameters that will be used as part of the build. Provided there were no errors, this configuration shouldn't need any tweaking* If you see any errors you're not able to solve, contact us through our [Discord channel](https://discord.gg/YhdMbvD).
-12. Now, go ahead and click "Generate". *This should generate a solution that you can load into Visual Studio in the build directory we specified initially in the CMake window.*
+12. *Once complete, the main window of CMake will fill with the various parameters that will be used as part of the build. Provided there were no errors, this configuration shouldn't need any tweaking* If you see any errors you're not able to solve, contact us through our [Discord channel](https://discord.gg/YhdMbvD).
+13. Now, go ahead and click "Generate". *This should generate a solution that you can load into Visual Studio in the build directory we specified initially in the CMake window.*
 
 ### Compiling the Code
 
-13. Open Visual Studio 2015 or 2017. 
-14. Use the normal file open menu to find the .sln solution file that CMake generated in the build directory and open it.
-15. Select the "Build" menu item and lick on "Build Solution". Now the project should compile. *This can take a few minutes. When its finished, under your build directory should be a directory named after the type of build (Debug, Release, RelWithDebInfo). This directory contains your compiled 'thyme.dll' and 'launchthyme.exe'.*
+14. Open Visual Studio 2015 or 2017. 
+15. Use the normal file open menu to find the .sln solution file that CMake generated in the build directory and open it.
+16. Select the "Build" menu item and lick on "Build Solution". Now the project should compile. *This can take a few minutes. When its finished, under your build directory should be a directory named after the type of build (Debug, Release, RelWithDebInfo). This directory contains your compiled 'thyme.dll' and 'launchthyme.exe'.*
 
 ### Troubleshooting
 


### PR DESCRIPTION
-Adding a list of programs which have to installed
-Shorten some parts a bit
-Left some notes about the S1023 DirectX SDK error.